### PR TITLE
Added some additional wrappers

### DIFF
--- a/src/META
+++ b/src/META
@@ -2,7 +2,6 @@ name = "xlib"
 version = "@VERSION@"
 description = "OCaml bindings to the Xlib library"
 requires = ""
-directory = "+Xlib"
 archive(byte) = "Xlib.cma"
 archive(native) = "Xlib.cmxa"
 

--- a/src/Xlib.ml
+++ b/src/Xlib.ml
@@ -1920,6 +1920,21 @@ type xSelectionEvent_contents = {
 external xSelectionEvent_datas: xSelectionEvent xEvent -> xSelectionEvent_contents = "ml_XSelectionEvent_datas"
 (** {{:http://tronche.com/gui/x/xlib/events/client-communication/selection.html}man} *)
 
+type xClientMessgeEvent_data =
+  | ClientMessageBytes of int array
+  | ClientMessageShorts of int array
+  | ClientMessageLongs of int array
+
+type xClientMessageEvent_contents = {
+  client_message_serial: uint;
+  client_message_send_event: bool;
+  client_message_display: display;
+  client_message_window: window;
+  client_message_type: atom;
+  client_message_data: xClientMessgeEvent_data;
+  }
+(** {{:http://tronche.com/gui/x/xlib/events/client-communication/client-message.html}man} *)
+
 type xCreateWindowEvent_contents = {
     createwindow_serial: uint;
     createwindow_send_event: bool;
@@ -1990,7 +2005,7 @@ type event_content =
   | XSelectionRequestEvCnt of todo_contents
   | XSelectionEvCnt        of xSelectionEvent_contents
   | XColormapEvCnt         of todo_contents
-  | XClientMessageEvCnt    of todo_contents
+  | XClientMessageEvCnt    of xClientMessageEvent_contents
   | XMappingEvCnt          of todo_contents
 
 

--- a/src/Xlib.ml
+++ b/src/Xlib.ml
@@ -563,6 +563,9 @@ external xDestroyWindow: dpy:display -> win:window -> unit = "ml_XDestroyWindow"
 external xid: int -> 'a = "caml_get_xid"
 (** some magic *)
 
+external xid_of_window: window -> int = "caml_get_xid_of_window"
+(** some magic *)
+
 external xStoreName: dpy:display -> win:window -> name:string -> unit = "ml_XStoreName"
 (** {{:http://tronche.com/gui/x/xlib/ICC/client-to-window-manager/XStoreName.html}man} *)
 

--- a/src/Xlib.ml
+++ b/src/Xlib.ml
@@ -116,6 +116,9 @@ external xFlush: dpy:display -> unit = "ml_XFlush"
 external xBell: dpy:display -> percent:int -> unit = "ml_XBell"
 (** {{:http://tronche.com/gui/x/xlib/input/XBell.html}man} *)
 
+external xLastKnownRequestProcessed: dpy:display -> int = "ml_LastKnownRequestProcessed"
+(** {{:https://tronche.com/gui/x/xlib/display/display-macros.html#LastKnownRequestProcessed}man} *)
+
 (* WIP *)
 external xChangeKeyboardControl_bell_percent: dpy:display -> bell_percent:int -> unit
    = "ml_XChangeKeyboardControl_bell_percent"

--- a/src/Xlib.ml
+++ b/src/Xlib.ml
@@ -792,6 +792,14 @@ external xGetWindowProperty_window:
       "ml_XGetWindowProperty_window"
 (** {{:http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html}man} *)
 
+external hasWindowProperty:
+    dpy:display ->
+    win:window ->
+    property:atom ->
+    bool
+    = "ml_hasWindowProperty"
+(* Try getting a property, and return whether it exists *)
+
 
 
 (** {3 XScreen} *)

--- a/src/Xlib.ml
+++ b/src/Xlib.ml
@@ -503,6 +503,14 @@ external xRootWindow: dpy:display -> scr:screen_number -> window = "ml_XRootWind
 external xDefaultRootWindow: dpy:display -> window = "ml_XDefaultRootWindow"
 (** {{:http://tronche.com/gui/x/xlib/display/display-macros.html#DefaultRootWindow}man} *)
 
+type focus_state =
+  | RevertToParent
+  | RevertToPointerRoot
+  | RevertToNone
+
+external xGetInputFocus: dpy:display -> (window option * focus_state) = "ml_XGetInputFocus"
+(** {{:https://tronche.com/gui/x/xlib/input/XGetInputFocus.html}man} *)
+
 #if defined(ML)
 let root_win ~dpy ?scr () =
   let scr =

--- a/src/wrap_xlib.c
+++ b/src/wrap_xlib.c
@@ -1013,6 +1013,11 @@ caml_get_xid(value xid)
     return Val_XID(Long_val(xid));
 }
 
+CAMLprim value
+caml_get_xid_of_window(value win)
+{
+    return Val_long(Window_val(win));
+}
 
 CAMLprim value
 ml_alloc_XVisualInfo( value unit )

--- a/src/wrap_xlib.c
+++ b/src/wrap_xlib.c
@@ -213,6 +213,15 @@ Eventmask_val( value em_list )
     return event_mask;
 }
 
+static inline value Focus_state_val(value mode) {
+    switch Int_val(mode) {
+        case 0:     return RevertToParent;
+        case 1:     return RevertToPointerRoot;
+        case 2:     return RevertToNone;
+        default:    caml_failwith("Unknown focus state value");
+    }
+}
+
 // }}}
 // {{{ macro/funcs 
 
@@ -467,6 +476,30 @@ ml_XGrabServer( value dpy )
     );
     //CHECK_STATUS(XGrabServer,1);
     return Val_unit;
+}
+
+static inline value Val_focus_state(int state)
+{
+    switch (state)
+    {
+        case RevertToParent:      return Val_int(0);
+        case RevertToPointerRoot: return Val_int(1);
+        case RevertToNone:        return Val_int(2);
+        default:                  caml_failwith("unhandled focus state");
+    }
+}
+
+CAMLprim value
+ml_XGetInputFocus( value dpy )
+{
+    CAMLlocal1(pair);
+    Window w;
+    int revert_to;
+    XGetInputFocus( Display_val(dpy), &w, &revert_to );
+    pair = caml_alloc(2, 0);
+    Store_field(pair, 0, (w == None) ? Val_none : Val_some(Val_Window(w)));
+    Store_field(pair, 1, Val_focus_state(revert_to));
+    return pair;
 }
 
 CAMLprim value

--- a/src/wrap_xlib.c
+++ b/src/wrap_xlib.c
@@ -1869,6 +1869,44 @@ ml_XGetWindowProperty_window_bytecode( value * argv, int argn )
                                          argv[3], argv[4], argv[5], argv[6] );
 }
 
+CAMLprim value
+ml_hasWindowProperty(
+        value dpy,
+        value win,
+        value property
+        )
+{
+    Atom actual_type;
+    Atom expected_type = Atom_val(property);
+    int actual_format;
+    unsigned long nitems, bytes_after;
+    Window *prop;
+
+    int result = XGetWindowProperty(
+        Display_val(dpy),
+        Window_val(win),
+        expected_type,
+        Long_val(0), // offset
+        Long_val(0), // length
+        0,           // delete
+        expected_type,
+        &actual_type,
+        &actual_format,
+        &nitems,
+        &bytes_after,
+        (unsigned char**)&prop
+    );
+    if (result != Success)
+        return Val_false;
+
+    XFree(prop);
+
+    if (actual_type != property)
+        return Val_false;
+
+    return Val_true;
+}
+
 
 /* Managing Installed Colormaps */
 

--- a/src/wrap_xlib.c
+++ b/src/wrap_xlib.c
@@ -4845,7 +4845,48 @@ ml_XSendEvent(
             caml_failwith("xSendEvent TODO: this event_content is not handled yet");
             break;
         case 29:  // XClientMessageEvCnt
-            caml_failwith("xSendEvent TODO: this event_content is not handled yet");
+            ev.type = ClientMessage;
+            ev.xclient.serial       = ULong_val(Field(cont, 0));
+            ev.xclient.send_event   = Bool_val(Field(cont, 1));
+            ev.xclient.display      = Display_val(Field(cont, 2));
+            ev.xclient.window       = Window_val(Field(cont, 3));
+            ev.xclient.message_type = Atom_val(Field(cont, 4));
+
+            value data = Field(cont, 5);
+            value array = Field(data, 0);
+            int len;
+            int actual_len = Wosize_val(array);
+            switch(Tag_val(data)) {
+                case 0: // bytes
+                    ev.xclient.format = 8;
+                    len = 20;
+                    if(len != actual_len) caml_failwith("xClientMessgeEvent_data expected an array of 20");
+                    while(--len >=0) {
+                        char val = (char)Int_val(Field(array, len));
+                        ev.xclient.data.b[len] = val;
+                    }
+                    break;
+                case 1: // shorts
+                    ev.xclient.format = 16;
+                    len = 10;
+                    if(len != actual_len) caml_failwith("xClientMessgeEvent_data expected an array of 10");
+                    while(--len >=0) {
+                        short val = (short)Int_val(Field(array, len));
+                        ev.xclient.data.s[len] = val;
+                    }
+                    break;
+                case 2: // longs
+                    ev.xclient.format = 32;
+                    len = 5;
+                    if(len != actual_len) caml_failwith("xClientMessgeEvent_data expected an array of 5");
+                    while(--len >=0) {
+                        long val = Int_val(Field(array, len));
+                        ev.xclient.data.l[len] = val;
+                    }
+                    break;
+                default:
+                    caml_failwith("xClientMessgeEvent_data unknown type");
+            }
             break;
         case 30:  // XMappingEvCnt
             caml_failwith("xSendEvent TODO: this event_content is not handled yet");

--- a/src/wrap_xlib.c
+++ b/src/wrap_xlib.c
@@ -435,6 +435,12 @@ ml_XBell( value dpy, value percent )
     return Val_unit;
 }
 
+CAMLprim value
+ml_LastKnownRequestProcessed( value dpy )
+{
+    return Val_long(LastKnownRequestProcessed(dpy));
+}
+
 static const int close_mode_table[] = {
     DestroyAll,
     RetainPermanent,


### PR DESCRIPTION
I've added some additional functionality I needed for [gsel](https://github.com/timbertson/gsel)

There are a couple of additional changes which aren't strictly new features:
- removed "directory" line from the META file. This seems to be unnecessary, and it breaks installations where `$PREFIX` is not equal to the ocaml installation path.
- added `hasWindowProperty`. Strictly you could just use `xGetWindowProperty`, but that has a lot of arguments if all you want to check is presence. Feel free to drop this if you don't like the fact it doesn't map directly to an xlib call though.

Also, there's another very similar repo at https://github.com/dmsh/ocaml-xlib. I'm not really sure which is more authoritative, but yours has more recent commits so I'm hoping it's this one ;)
